### PR TITLE
Breaking Change! - Function calls restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # insightcloudsec
 Go Module for Interacting with InsightCloudSec API (formerly DivvyCloud)
 
+### General Usage
+
+```go 
+package main
+
+import(
+    "github.com/gstotts/insightcloudsec"
+)
+
+func main() {
+    config := insightcloudsec.Config{
+        BaseURL: "http://localhost:8001",
+        ApiKey: "1232351351235ABSLAFL:JSDFA"
+    }
+
+    // Can also use environment variables above and pass nil
+    ics := insightcloudsec.NewClient(config)
+}
+
+```
+
 ### Examples
 
 <details><summary>List Clouds</summary>
@@ -16,12 +37,12 @@ import (
 
 func main() {
 	// Get a client
-	c, err := insightcloudsec.NewClient()
+	c, err := insightcloudsec.NewClient(nil)
 	if err != nil {
 		fmt.Println(err)
 	}
 
-	clouds, err := c.ListClouds()
+	clouds, err := c.Clouds.List()
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -44,12 +65,12 @@ import (
 
 func main() {
 	// Get a client
-	c, err := insightcloudsec.NewClient()
+	c, err := insightcloudsec.NewClient(nil)
 	if err != nil {
 		fmt.Println(err)
 	}
 
-	types, err := c.ListCloudTypes()
+	types, err := c.Clouds.ListTypes()
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -73,12 +94,12 @@ import (
 
 func main() {
 	// Get a client
-	c, err := insightcloudsec.NewClient()
+	c, err := insightcloudsec.NewClient(nil)
 	if err != nil {
 		fmt.Println(err)
 	}
 
-	clouds, err := c.ListClouds()
+	clouds, err := c.Clouds.ListClouds()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -108,12 +129,12 @@ import (
 
 func main() {
 	// Get a client
-	c, err := insightcloudsec.NewClient()
+	c, err := insightcloudsec.NewClient(nil)
 	if err != nil {
 		fmt.Println(err)
 	}
 
-	hs, err := c.ListHarvestingStrategies()
+	hs, err := c.Clouds.ListHarvestingStrategies()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -147,8 +168,8 @@ func main() {
 	insight.ResourceTypes = []string{"divvyorganizationservice"}
 	insight.Filters = []insightcloudsec.InsightFilter{filter}
 
-	ics, _ := insightcloudsec.NewClient()
-	ics.Create_Insight(insight)
+	ics, _ := insightcloudsec.NewClient(nil)
+	ics.Insights.Create(insight)
 
 }
 
@@ -168,12 +189,12 @@ import (
 
 func main() {
 	// Get a client
-	c, err := insightcloudsec.NewClient()
+	c, err := insightcloudsec.NewClient(nil)
 	if err != nil {
 		fmt.Println(err)
 	}
 
-	insights, err := c.List_Insights()
+	insights, err := c.Insights.List()
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -198,7 +219,7 @@ import (
 )
 
 func main() {
-	ics, _ := insightcloudsec.NewClient()
+	ics, _ := insightcloudsec.NewClient(nil)
 
 	azure_cloud := insightcloudsec.AzureCloudAccount{
 		CreationParameters: insightcloudsec.CloudAccountParameters{
@@ -211,7 +232,7 @@ func main() {
 			AppID:          "01234567-1234-1234-1234-012345678901",
 		},
 	}
-	account, err := ics.AddAzureCloud(azure_cloud)
+	account, err := ics.Clouds.AddAzureCloud(azure_cloud)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -233,8 +254,8 @@ import (
 )
 
 func main() {
-	ics, _ := insightcloudsec.NewClient()
-	details, err := ics.CreateUser(insightcloudsec.User{
+	ics, _ := insightcloudsec.NewClient(nil)
+	details, err := ics.Users.Create(insightcloudsec.User{
 		Name:        "Testy McTester",
 		Username:    "tmctester",
 		Email:       "tmctester@test.com",

--- a/authentication_servers.go
+++ b/authentication_servers.go
@@ -5,12 +5,17 @@ import (
 	"net/http"
 )
 
-// CONSTANTS
-///////////////////////////////////////////
+var _ AuthenticationServers = (*authServers)(nil)
 
-// STRUCTS
-///////////////////////////////////////////
-type Authentication_Server struct {
+type AuthenticationServers interface {
+	List() (AuthenticationServersList, error)
+}
+
+type authServers struct {
+	client *Client
+}
+
+type AuthenticationServer struct {
 	ID           int    `json:"server_id"`
 	Name         string `json:"server_name"`
 	Host         string `json:"server_host"`
@@ -21,22 +26,19 @@ type Authentication_Server struct {
 	MappedGroups int    `json:"mapped_groups"`
 }
 
-type Authentication_Servers struct {
-	Servers []Authentication_Server `json:"servers"`
+type AuthenticationServersList struct {
+	Servers []AuthenticationServer `json:"servers"`
 }
 
-// AUTH SERVER FUNCTIONS
-///////////////////////////////////////////
-
-func (c Client) List_Authentication_Servers() (Authentication_Servers, error) {
-	resp, err := c.makeRequest(http.MethodPost, "/v2/prototype/authenticationservers/list", nil)
+func (s *authServers) List() (AuthenticationServersList, error) {
+	resp, err := s.client.makeRequest(http.MethodPost, "/v2/prototype/authenticationservers/list", nil)
 	if err != nil {
-		return Authentication_Servers{}, err
+		return AuthenticationServersList{}, err
 	}
 
-	var ret Authentication_Servers
+	var ret AuthenticationServersList
 	if err := json.NewDecoder(resp.Body).Decode(&ret); err != nil {
-		return Authentication_Servers{}, err
+		return AuthenticationServersList{}, err
 	}
 
 	return ret, nil

--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,16 @@ import (
 	"net/http"
 )
 
+// MissingConfigError is a type of error raised by create a client without required config elements
+type MissingConfigError struct {
+	MissingItem string
+	Details     string
+}
+
+func (e MissingConfigError) Error() string {
+	return fmt.Sprintf("\nError:\nMissing configuration item: %s\n%s", e.MissingItem, e.Details)
+}
+
 // APIRequestError is a type of error raised by API calls made from this library
 type APIRequestError struct {
 	Request    http.Request

--- a/filters.go
+++ b/filters.go
@@ -8,30 +8,37 @@ import (
 	"net/http"
 )
 
-// STRUCTS
-///////////////////////////////////////////
+var _ Filters = (*filters)(nil)
 
-type Filter_Registry_Result struct {
-	ID                  string                   `json:"filter_id"`
-	Name                string                   `json:"name"`
-	Description         string                   `json:"description"`
-	Supported_Resources []string                 `json:"supported_resources"`
-	Supports_Common     bool                     `json:"supports_common"`
-	Supported_Clouds    []string                 `json:"supported_clouds"`
-	Settings_Config     []Filter_Registry_Config `json:"settings_config"`
+type Filters interface {
+	Get_Registry() (map[string]FilterRegistryResult, error)
 }
 
-type Filter_Registry_Config struct {
-	Field_Type   string                           `json:"field_type"`
-	Name         string                           `json:"name"`
-	Display_Name string                           `json:"display_name"`
-	Description  interface{}                      `json:"description"` // Should be string but divvy.query.shared_file_system_lifecycle_policy was returning an array for a boolean field
-	Options      []string                         `json:"options"`
-	Choices      []Filter_Registry_Config_Choices `json:"choices"`
-	State_Hash   string                           `json:"_state_hash"`
+type filters struct {
+	client *Client
 }
 
-type Filter_Registry_Config_Choices struct {
+type FilterRegistryResult struct {
+	ID                  string                 `json:"Filterid"`
+	Name                string                 `json:"name"`
+	Description         string                 `json:"description"`
+	Supported_Resources []string               `json:"supported_resources"`
+	Supports_Common     bool                   `json:"supports_common"`
+	Supported_Clouds    []string               `json:"supported_clouds"`
+	Settings_Config     []FilterRegistryConfig `json:"settings_config"`
+}
+
+type FilterRegistryConfig struct {
+	Field_Type   string                         `json:"field_type"`
+	Name         string                         `json:"name"`
+	Display_Name string                         `json:"display_name"`
+	Description  interface{}                    `json:"description"` // Should be string but divvy.query.shared_file_system_lifecycle_policy was returning an array for a boolean field
+	Options      []string                       `json:"options"`
+	Choices      []FilterRegistryConfig_Choices `json:"choices"`
+	State_Hash   string                         `json:"_state_hash"`
+}
+
+type FilterRegistryConfig_Choices struct {
 	Value         string `json:"value"`
 	Display_Value string `json:"display_value"`
 }
@@ -39,14 +46,14 @@ type Filter_Registry_Config_Choices struct {
 // FUNCTIONS
 ///////////////////////////////////////////
 
-func (c Client) Get_Filter_Registry() (map[string]Filter_Registry_Result, error) {
+func (f *filters) Get_Registry() (map[string]FilterRegistryResult, error) {
 	// Returns a map of filter registry results
-	resp, err := c.makeRequest(http.MethodGet, "/v2/public/insights/filter-registry", nil)
+	resp, err := f.client.makeRequest(http.MethodGet, "/v2/public/insights/filter-registry", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	var fr map[string]Filter_Registry_Result
+	var fr map[string]FilterRegistryResult
 	if err := json.NewDecoder(resp.Body).Decode(&fr); err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
 module github.com/gstotts/insightcloudsec
 
-go 1.18
-
-require golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
-
-require golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
+go 1.17

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,1 @@
-golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
-golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+

--- a/organizations.go
+++ b/organizations.go
@@ -7,72 +7,82 @@ import (
 	"net/http"
 )
 
-// STRUCTS
-///////////////////////////////////////////
-type Organization struct {
+var _ Organizations = (*orgs)(nil)
+
+type Organizations interface {
+	Create(name string) error
+	Edit_Name(resource_id int, name string) error
+	Delete(resource_id int) error
+	List() ([]organizations, error)
+	Switch(name string) error
+}
+
+type orgs struct {
+	client *Client
+}
+
+type organization struct {
 	Name string `json:"organization_name"`
 }
 
-type Organizations struct {
+type organizations struct {
 	Name string `json:"name"`
 	ID   int    `json:"organization_id"`
 }
 
-// ORGANIZATION CLIENT FUNCTIONS
-///////////////////////////////////////////
-func (c Client) Create_Organization(name string) error {
-	data, err := json.Marshal(Organization{Name: name})
+func (c *orgs) Create(name string) error {
+	data, err := json.Marshal(organization{Name: name})
 	if err != nil {
 		return fmt.Errorf("[-] error marshalling organization")
 	}
-	resp, err := c.makeRequest(http.MethodPost, "/v2/prototype/domain/organization/create", bytes.NewBuffer(data))
+	resp, err := c.client.makeRequest(http.MethodPost, "/v2/prototype/domain/organization/create", bytes.NewBuffer(data))
 	if err != nil || resp.StatusCode != 200 {
 		return err
 	}
 	return nil
 }
 
-func (c Client) Switch_Organization(name string) error {
-	data, err := json.Marshal(Organization{Name: name})
+func (c *orgs) Switch(name string) error {
+	data, err := json.Marshal(organization{Name: name})
 	if err != nil {
 		return fmt.Errorf("[-] error marshalling organization")
 	}
-	resp, err := c.makeRequest(http.MethodPost, "/v2/prototype/domain/switch_organization", bytes.NewBuffer(data))
+	resp, err := c.client.makeRequest(http.MethodPost, "/v2/prototype/domain/switch_organization", bytes.NewBuffer(data))
 	if err != nil || resp.StatusCode != 200 {
 		return err
 	}
 	return nil
 }
 
-func (c Client) Edit_Organization_Name(resource_id int, name string) error {
-	data, err := json.Marshal(Organization{Name: name})
+func (c *orgs) Edit_Name(resource_id int, name string) error {
+	data, err := json.Marshal(organization{Name: name})
 	if err != nil {
 		return fmt.Errorf("[-] error marshalling organization")
 	}
-	resp, err := c.makeRequest(http.MethodPost, fmt.Sprintf("/v2/prototype/domain/organization/divvyorganization:%d/update", resource_id), bytes.NewBuffer(data))
+	resp, err := c.client.makeRequest(http.MethodPost, fmt.Sprintf("/v2/prototype/domain/organization/divvyorganization:%d/update", resource_id), bytes.NewBuffer(data))
 	if err != nil || resp.StatusCode != 200 {
 		return err
 	}
 	return nil
 }
 
-func (c Client) Delete_Organization(resource_id int) error {
-	resp, err := c.makeRequest(http.MethodDelete, fmt.Sprintf("/v2/prototype/domain/organization/divvyorganization:%d/delete", resource_id), nil)
+func (c *orgs) Delete(resource_id int) error {
+	resp, err := c.client.makeRequest(http.MethodDelete, fmt.Sprintf("/v2/prototype/domain/organization/divvyorganization:%d/delete", resource_id), nil)
 	if err != nil || resp.StatusCode != 200 {
 		return err
 	}
 	return nil
 }
 
-func (c Client) List_Organizations() ([]Organizations, error) {
-	resp, err := c.makeRequest(http.MethodGet, "/v2/prototype/domain/organizations/get", nil)
+func (c *orgs) List() ([]organizations, error) {
+	resp, err := c.client.makeRequest(http.MethodGet, "/v2/prototype/domain/organizations/get", nil)
 	if err != nil {
-		return []Organizations{}, err
+		return []organizations{}, err
 	}
 
-	var ret []Organizations
+	var ret []organizations
 	if err := json.NewDecoder(resp.Body).Decode(&ret); err != nil {
-		return []Organizations{}, err
+		return []organizations{}, err
 	}
 	return ret, nil
 }


### PR DESCRIPTION
Restructure of how functions are arranged to be consumed... now you can use the client to get to various resource types and call functions.  For example, instead of calling `insightcloudsec.Client.CreateBadges()` it's `insightcloudsec.Badges.Create()`